### PR TITLE
Use `window.reTree` if already set instead of `require`

### DIFF
--- a/ua-device-detector.js
+++ b/ua-device-detector.js
@@ -549,7 +549,7 @@
     }
 
     if (!!module && !!require) {
-        var reTree = require("re-tree");
+        var reTree = (window && window.reTree) || require("re-tree");
         module.exports = {
             parseUserAgent: function (ua, customDetectors) {
                 return parseUserAgent({ reTree: reTree || {}, customDetectors: customDetectors || [], userAgent: ua || "" });


### PR DESCRIPTION
In webpack and parcel-bundler the `require('re-tree')` isn't processed in this file because of the indirect use of `require`.  With this change, you can import re-tree directly prior to importing ua-device-detector and this code will not attempt to `require` it.