### PR TITLE
BUG: cannot use EcmaScript import syntax to include the library. FIXED

### DIFF
--- a/ua-device-detector.js
+++ b/ua-device-detector.js
@@ -307,7 +307,7 @@
             return value;
         };
     }
-    
+
 // https://tc39.github.io/ecma262/#sec-array.prototype.find
     if (!Array.prototype.find) {
         Object.defineProperty(Array.prototype, "find", {
@@ -351,7 +351,7 @@
                 return undefined;
             }
         });
-    }    
+    }
     /* ES5 polyfills End*/
 
     function parseUserAgent(options) {
@@ -432,7 +432,7 @@
         ].reduce(function (previousValue, currentValue) {
             return (previousValue === DEVICES.UNKNOWN && deviceInfo.raw.device[currentValue]) ? currentValue : previousValue;
         }, DEVICES.UNKNOWN);
-        
+
         deviceInfo.os_version = "unknown";
         if (deviceInfo.os !== OS.UNKNOWN) {
             var version = (OS_VERSIONS_RE[deviceInfo.os]||[])
@@ -444,7 +444,7 @@
                         {
                             return reMap.map;
                         }
-                        else 
+                        else
                         {
                             return reMap.map.call(null,res[1]);
                         }
@@ -509,7 +509,7 @@
             custom[customDetector.name] = reTree.test(ua, customDetector.re);
             return custom;
         }, {});
-        
+
         return deviceInfo;
     }
 
@@ -548,7 +548,7 @@
         };
     }
 
-    if (!!module && !!require) {
+    if (!!module) {
         var reTree = (window && window.reTree) || require("re-tree");
         module.exports = {
             parseUserAgent: function (ua, customDetectors) {


### PR DESCRIPTION
The bug was in this conditional check --> `if (!!module && !!require)`.
That `!!require` messes all up, because require is a reserved word that implies the call of the native require function, which requires an argument  (e.g `require('moduleName')`) , so basically before the fix it happens that the require function gets called without arguments firing the `webpackMissingModule` exception which interrupt the execution of that code block skipping the lines of code that follows it.

I simply removed the `!!require` check to solve the problem.

I understand that your purpose was to check if the require function is defined, but I'm afraid it isn't possible to check. Consider also that if the require function is not defined, the import fires an exception which is the exact behaviour that happens now, so I guess that removing it is quite safe.

@srfrnk please let me know if it is ok for you.

Simone